### PR TITLE
Removed redundant $settings['install_profile']from settings.php

### DIFF
--- a/web/sites/default/settings.php
+++ b/web/sites/default/settings.php
@@ -162,5 +162,3 @@ if (file_exists(__DIR__ . '/settings.local.php')) {
 if (file_exists(__DIR__ . '/services.local.yml')) {
   $settings['container_yamls'][] = __DIR__ . '/services.local.yml';
 }
-
-$settings['install_profile'] = 'config_installer';


### PR DESCRIPTION
Drupal 8 no longer uses the $settings['install_profile'] value in settings.php, the status report says "Drupal 8 no longer uses the $settings['install_profile'] value in settings.php and it can be removed."