### PR TITLE
Make correction uppercase characters fix this as Composer 2.0 will er…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "behat/mink-goutte-driver": "~1.2",
         "jcalderonzumba/gastonjs": "~1.0.2",
         "jcalderonzumba/mink-phantomjs-driver": "~0.3.1",
-        "mikey179/vfsStream": "~1.2",
+        "mikey179/vfsstream": "~1.2",
         "phpunit/phpunit": "~4.8",
         "symfony/css-selector": "~2.8"
     },


### PR DESCRIPTION
When we were trying to perform docker-compose up, error: Deprecation warning: require-dev.mikey179/vfsStream is invalid, it should not contain uppercase characters. Please use mikey179/vfsstream instead. Make sure you fix this as Composer 2.0 will error is presented, composer 2.0 does not accept uppercase character packages, this PR fixes this problem.