### PR TITLE
Reverse the updatedb/cim order.

### DIFF
--- a/.lagoon.yml
+++ b/.lagoon.yml
@@ -20,12 +20,12 @@ tasks:
         service: cli
         shell: bash
     - run:
-        name: drush cim
-        command: drush -y cim
-        service: cli
-    - run:
         name: drush updb
         command: drush -y updb
+        service: cli
+    - run:
+        name: drush cim
+        command: drush -y cim
         service: cli
     - run:
         name: drush cr


### PR DESCRIPTION
I think it's generally accepted that updatedb should go before config-import . Both orders [can cause issues](https://drupal.stackexchange.com/questions/188840/what-order-should-configuration-import-and-module-updates-be-run), but updates can be more weird, and since developers have more control over the config-import then they are more likely to be able to resolve config issues.